### PR TITLE
fix: update README file delimiter in DMG creation process

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -141,7 +141,7 @@ jobs:
             xattr -cr "$DMG_DIR/$APP_NAME"
             
             # Create README file
-            cat > "$DMG_DIR/README.txt" << 'README'
+            cat > "$DMG_DIR/README.txt" << 'EOF'
 Json Studio Installation Guide
 ===============================
 
@@ -186,7 +186,7 @@ Option B - Manual fix in Finder:
 Need Help?
 ----------
 Report issues at: https://github.com/degjs/JsonStudio/issues
-README
+EOF
             
             # Create one-click install script
             cat > "$DMG_DIR/Install.command" << 'INSTALL_SCRIPT'


### PR DESCRIPTION
- Change the delimiter for the README file from 'README' to 'EOF' for consistency in the GitHub Actions workflow.
- Ensure proper formatting and readability of the installation guide within the DMG.