### PR TITLE
chore: update GitHub Actions workflow to upload artifacts for multipl…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -321,12 +321,43 @@ jobs:
             fi
           fi
 
-      - name: Upload artifacts to release
+      - name: Upload Windows artifacts
+        if: matrix.platform == 'windows-latest'
         uses: softprops/action-gh-release@v1
         with:
           files: |
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*windows*.exe
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: 'Json Studio ${{ github.event.inputs.tag_name || github.ref_name }}'
+          body: 'View changelog: https://github.com/${{ github.repository }}/releases'
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: false
+          overwrite: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload macOS artifacts
+        if: matrix.platform == 'macos-latest'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*_installer.dmg
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          name: 'Json Studio ${{ github.event.inputs.tag_name || github.ref_name }}'
+          body: 'View changelog: https://github.com/${{ github.repository }}/releases'
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: false
+          overwrite: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Linux artifacts
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
             src-tauri/target/${{ matrix.target }}/release/bundle/**/*linux*.AppImage
           tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           name: 'Json Studio ${{ github.event.inputs.tag_name || github.ref_name }}'
@@ -334,5 +365,6 @@ jobs:
           draft: true
           prerelease: false
           fail_on_unmatched_files: false
+          overwrite: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…e platforms

- Modify the build-release.yml to include separate upload steps for Windows, macOS, and Linux artifacts.
- Ensure each platform's artifacts are uploaded with appropriate naming and tagging conventions.
- Set the upload steps to draft releases, allowing for review before finalization.