### PR TITLE
chore: update version to 0.3.0 across project files

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -290,42 +290,48 @@ jobs:
           
           if [ "${{ matrix.platform }}" == "windows-latest" ]; then
             # Windows: rename .exe files (Tauri may replace spaces with dots in filename)
-            # Try both "Json Studio" and "Json.Studio" formats
-            ORIGINAL_EXE1="$BUNDLE_DIR/nsis/Json Studio_${VERSION#v}_x64-setup.exe"
-            ORIGINAL_EXE2="$BUNDLE_DIR/nsis/Json.Studio_${VERSION#v}_x64-setup.exe"
+            # Match any version suffix to avoid mismatches between tag and app version.
+            shopt -s nullglob
+            CANDIDATES=(
+              "$BUNDLE_DIR/nsis/Json Studio"*"_x64-setup.exe"
+              "$BUNDLE_DIR/nsis/Json.Studio"*"_x64-setup.exe"
+            )
             RENAMED_EXE="$BUNDLE_DIR/nsis/Json Studio_${VERSION#v}_windows_${{ matrix.arch_suffix }}-setup.exe"
             
-            if [ -f "$ORIGINAL_EXE1" ]; then
-              mv "$ORIGINAL_EXE1" "$RENAMED_EXE"
-              echo "✓ Renamed Windows installer: $RENAMED_EXE"
-            elif [ -f "$ORIGINAL_EXE2" ]; then
-              mv "$ORIGINAL_EXE2" "$RENAMED_EXE"
-              echo "✓ Renamed Windows installer: $RENAMED_EXE"
+            if [ ${#CANDIDATES[@]} -gt 0 ]; then
+              ORIGINAL_EXE="${CANDIDATES[0]}"
+              if [ "$ORIGINAL_EXE" == "$RENAMED_EXE" ]; then
+                echo "✓ Windows installer already named: $RENAMED_EXE"
+              else
+                mv "$ORIGINAL_EXE" "$RENAMED_EXE"
+                echo "✓ Renamed Windows installer: $RENAMED_EXE"
+              fi
             else
               echo "❌ Windows installer not found"
-              echo "Looking for: $ORIGINAL_EXE1"
-              echo "Or: $ORIGINAL_EXE2"
               echo "Files in nsis directory:"
               ls -la "$BUNDLE_DIR/nsis/" || true
               exit 1
             fi
           elif [ "${{ matrix.platform }}" == "ubuntu-22.04" ]; then
             # Linux: rename AppImage (Tauri may replace spaces with dots in filename)
-            # Try both "Json Studio" and "Json.Studio" formats
-            ORIGINAL_APPIMAGE1="$BUNDLE_DIR/appimage/Json Studio_${VERSION#v}_amd64.AppImage"
-            ORIGINAL_APPIMAGE2="$BUNDLE_DIR/appimage/Json.Studio_${VERSION#v}_amd64.AppImage"
+            # Match any version suffix to avoid mismatches between tag and app version.
+            shopt -s nullglob
+            CANDIDATES=(
+              "$BUNDLE_DIR/appimage/Json Studio"*"_amd64.AppImage"
+              "$BUNDLE_DIR/appimage/Json.Studio"*"_amd64.AppImage"
+            )
             RENAMED_APPIMAGE="$BUNDLE_DIR/appimage/Json Studio_${VERSION#v}_linux_${{ matrix.arch_suffix }}.AppImage"
             
-            if [ -f "$ORIGINAL_APPIMAGE1" ]; then
-              mv "$ORIGINAL_APPIMAGE1" "$RENAMED_APPIMAGE"
-              echo "✓ Renamed Linux AppImage: $RENAMED_APPIMAGE"
-            elif [ -f "$ORIGINAL_APPIMAGE2" ]; then
-              mv "$ORIGINAL_APPIMAGE2" "$RENAMED_APPIMAGE"
-              echo "✓ Renamed Linux AppImage: $RENAMED_APPIMAGE"
+            if [ ${#CANDIDATES[@]} -gt 0 ]; then
+              ORIGINAL_APPIMAGE="${CANDIDATES[0]}"
+              if [ "$ORIGINAL_APPIMAGE" == "$RENAMED_APPIMAGE" ]; then
+                echo "✓ Linux AppImage already named: $RENAMED_APPIMAGE"
+              else
+                mv "$ORIGINAL_APPIMAGE" "$RENAMED_APPIMAGE"
+                echo "✓ Renamed Linux AppImage: $RENAMED_APPIMAGE"
+              fi
             else
               echo "❌ Linux AppImage not found"
-              echo "Looking for: $ORIGINAL_APPIMAGE1"
-              echo "Or: $ORIGINAL_APPIMAGE2"
               echo "Files in appimage directory:"
               ls -la "$BUNDLE_DIR/appimage/" || true
               exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Json Studio",
-  "version": "0.0.3",
+  "version": "0.3.0",
   "description": "Fast, modern, and efficient JSON desktop tool",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "jsonstudio"
-version = "0.0.3"
+version = "0.3.0"
 dependencies = [
  "cocoa",
  "objc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonstudio"
-version = "0.0.3"
+version = "0.3.0"
 description = "Fast, modern, and efficient JSON desktop tool"
 authors = ["sundegan"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Json Studio",
-  "version": "0.0.3",
+  "version": "0.3.0",
   "identifier": "com.jsonstudio.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
- Bump version number from 0.0.3 to 0.3.0 in package.json, Cargo.toml, Cargo.lock, and tauri.conf.json to reflect the latest release.
- Ensure consistency in versioning across all relevant configuration files.