### PR TITLE
fix: file open event

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "sundegan",
   "dependencies": {
     "@monaco-editor/loader": "^1.7.0",
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-opener": "^2",
     "bits-ui": "^2.15.2",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@tauri-apps/api':
-        specifier: ^2
-        version: 2.9.1
+        specifier: ^2.10.1
+        version: 2.10.1
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.2
@@ -539,8 +539,8 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  '@tauri-apps/api@2.9.1':
-    resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
+  '@tauri-apps/api@2.10.1':
+    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
   '@tauri-apps/cli-darwin-arm64@2.9.6':
     resolution: {integrity: sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==}
@@ -1371,7 +1371,7 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 6.4.1(jiti@2.6.1)(lightningcss@1.30.2)
 
-  '@tauri-apps/api@2.9.1': {}
+  '@tauri-apps/api@2.10.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.9.6':
     optional: true
@@ -1422,7 +1422,7 @@ snapshots:
 
   '@tauri-apps/plugin-opener@2.5.2':
     dependencies:
-      '@tauri-apps/api': 2.9.1
+      '@tauri-apps/api': 2.10.1
 
   '@types/cookie@0.6.0': {}
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,11 +4,12 @@ use commands::json::{json_format, json_minify, json_stats, json_validate, json_e
 use commands::window::{set_window_theme, open_devtools};
 use commands::shortcuts::{show_main_window, format_clipboard_and_show, update_shortcut};
 use commands::file::{open_file_dialog, save_file, save_file_dialog, read_file, is_json_file, get_file_name};
+use tauri::Emitter;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
@@ -34,6 +35,30 @@ pub fn run() {
                     let _ = format_clipboard_and_show(handle).await;
                 });
             }).map_err(|e| format!("Failed to register format clipboard shortcut: {}", e))?;
+
+            // Windows/Linux: file paths are passed via command line arguments
+            #[cfg(not(target_os = "macos"))]
+            {
+                use std::path::Path;
+                let paths: Vec<String> = std::env::args()
+                    .skip(1)
+                    .filter(|arg| !arg.starts_with('-'))
+                    .filter(|arg| {
+                        let p = Path::new(arg);
+                        p.exists() && p.extension().and_then(|e| e.to_str())
+                            .map(|e| e.eq_ignore_ascii_case("json"))
+                            .unwrap_or(false)
+                    })
+                    .collect();
+
+                if !paths.is_empty() {
+                    let handle = app.handle().clone();
+                    tauri::async_runtime::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        let _ = handle.emit("open-file", paths);
+                    });
+                }
+            }
             
             Ok(())
         })
@@ -56,6 +81,27 @@ pub fn run() {
             is_json_file,
             get_file_name
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        // macOS: file open events come through RunEvent::Opened
+        #[cfg(target_os = "macos")]
+        if let tauri::RunEvent::Opened { urls } = event {
+            let paths: Vec<String> = urls
+                .iter()
+                .filter_map(|url| {
+                    if url.scheme() == "file" {
+                        url.to_file_path().ok().map(|p| p.to_string_lossy().into_owned())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if !paths.is_empty() {
+                let _ = app_handle.emit("open-file", paths);
+            }
+        }
+    });
 }

--- a/src/lib/components/editor/JsonEditor.svelte
+++ b/src/lib/components/editor/JsonEditor.svelte
@@ -84,6 +84,7 @@
     let unlistenFormatted: (() => void) | null = null;
     let unlistenRaw: (() => void) | null = null;
     let unlistenFileDrop: (() => void) | null = null;
+    let unlistenOpenFile: (() => void) | null = null;
     
     (async () => {
       const { listen } = await import('@tauri-apps/api/event');
@@ -113,7 +114,6 @@
       });
 
       // Listen for file drop events
-      // Tauri 2.0 uses 'tauri://drag-drop' event
       unlistenFileDrop = await listen<{ paths: string[], position: { x: number, y: number } }>('tauri://drag-drop', async (event) => {
         const paths = event.payload?.paths;
         if (paths && paths.length > 0) {
@@ -122,16 +122,28 @@
             const fileContent = await readFile(filePath);
             const name = await getFileName(filePath);
             
-            const currentTab = $activeTab;
-            
-            // Always create a new tab for dropped files
             tabsStore.addTab(fileContent, filePath, name);
-            // Content and editor will be updated by $effect when tab switches
-            
             showToast(`Opened: ${name || 'file'}`);
           } catch (e) {
             showToast('Failed to open file');
             console.error('Drop file error:', e);
+          }
+        }
+      });
+
+      // Listen for file open events (macOS "Open With" / double-click)
+      unlistenOpenFile = await listen<string[]>('open-file', async (event) => {
+        const paths = event.payload;
+        if (!paths || paths.length === 0) return;
+        for (const filePath of paths) {
+          try {
+            const fileContent = await readFile(filePath);
+            const name = await getFileName(filePath);
+            tabsStore.addTab(fileContent, filePath, name);
+            showToast(`Opened: ${name || 'file'}`);
+          } catch (e) {
+            showToast('Failed to open file');
+            console.error('Open file error:', e);
           }
         }
       });
@@ -231,6 +243,7 @@
       if (unlistenFormatted) unlistenFormatted();
       if (unlistenRaw) unlistenRaw();
       if (unlistenFileDrop) unlistenFileDrop();
+      if (unlistenOpenFile) unlistenOpenFile();
       if (diffModeUnsubscribe) diffModeUnsubscribe();
       window.removeEventListener('keydown', handleKeydown);
     };


### PR DESCRIPTION
- Updated the @tauri-apps/api dependency in package.json and pnpm-lock.yaml to version 2.10.1 for improved functionality.
- Added support for file open events in JsonEditor.svelte, allowing users to open files via macOS "Open With" and double-click actions.
- Enhanced the Tauri application to handle file paths passed via command line arguments on Windows/Linux, emitting an "open-file" event for JSON files.