### PR TITLE
fix: Monaco editor blank in packaged desktop app

### DIFF
--- a/src/lib/components/editor/CodeGenView.svelte
+++ b/src/lib/components/editor/CodeGenView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import loader from '@monaco-editor/loader';
   import type * as Monaco from 'monaco-editor';
+  import { initMonaco } from '$lib/services/monaco';
   import { registerMonacoThemes, type EditorTheme } from '$lib/config/monacoThemes';
   import { generateCode, codeToJson, supportsReverse, CODEGEN_LANGUAGES, type CodegenLanguage } from '$lib/services/codegen';
   import { t } from '$lib/i18n';
@@ -231,7 +231,7 @@
   }
 
   onMount(async () => {
-    const monacoInstance = await loader.init();
+    const monacoInstance = await initMonaco();
     monaco = monacoInstance;
     registerMonacoThemes(monacoInstance);
 

--- a/src/lib/components/editor/ConvertView.svelte
+++ b/src/lib/components/editor/ConvertView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import loader from '@monaco-editor/loader';
   import type * as Monaco from 'monaco-editor';
+  import { initMonaco } from '$lib/services/monaco';
   import { registerMonacoThemes, type EditorTheme } from '$lib/config/monacoThemes';
   import { convertJson, convertToJson, CONVERT_FORMATS, type ConvertFormat } from '$lib/services/convert';
   import { t } from '$lib/i18n';
@@ -316,7 +316,7 @@
   }
 
   onMount(async () => {
-    const monacoInstance = await loader.init();
+    const monacoInstance = await initMonaco();
     monaco = monacoInstance;
     registerMonacoThemes(monacoInstance);
     registerCsvLanguage(monacoInstance);

--- a/src/lib/components/editor/MonacoDiffEditor.svelte
+++ b/src/lib/components/editor/MonacoDiffEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import loader from '@monaco-editor/loader';
   import type * as Monaco from 'monaco-editor';
+  import { initMonaco } from '$lib/services/monaco';
   import { registerMonacoThemes, type EditorTheme } from '$lib/config/monacoThemes';
 
   let {
@@ -107,7 +107,7 @@
   });
 
   onMount(async () => {
-    const monacoInstance = await loader.init();
+    const monacoInstance = await initMonaco();
     monaco = monacoInstance;
 
     registerMonacoThemes(monacoInstance);

--- a/src/lib/components/editor/MonacoEditor.svelte
+++ b/src/lib/components/editor/MonacoEditor.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   // Monaco Editor Svelte wrapper component
   import { onMount, onDestroy } from 'svelte';
-  import loader from '@monaco-editor/loader';
   import type * as Monaco from 'monaco-editor';
+  import { initMonaco } from '$lib/services/monaco';
   import { registerMonacoThemes, type EditorTheme } from '$lib/config/monacoThemes';
   
   // Props
@@ -136,7 +136,7 @@
   
   onMount(async () => {
     // Use loader to load Monaco (automatically handles worker)
-    const monacoInstance = await loader.init();
+    const monacoInstance = await initMonaco();
     monaco = monacoInstance;
     
     // Register custom themes (loaded from config file)

--- a/src/lib/components/editor/SchemaView.svelte
+++ b/src/lib/components/editor/SchemaView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import loader from '@monaco-editor/loader';
   import type * as Monaco from 'monaco-editor';
+  import { initMonaco } from '$lib/services/monaco';
   import { registerMonacoThemes, type EditorTheme } from '$lib/config/monacoThemes';
   import { generateSchema, validateWithSchema, type SchemaError } from '$lib/services/schema';
   import { t } from '$lib/i18n';
@@ -143,7 +143,7 @@
   }
 
   onMount(async () => {
-    const monacoInstance = await loader.init();
+    const monacoInstance = await initMonaco();
     monaco = monacoInstance;
     registerMonacoThemes(monacoInstance);
 

--- a/src/lib/services/monaco.ts
+++ b/src/lib/services/monaco.ts
@@ -1,0 +1,18 @@
+import loader from '@monaco-editor/loader';
+import * as monaco from 'monaco-editor';
+
+let monacoInitPromise: Promise<typeof monaco> | null = null;
+
+/**
+ * Initialize Monaco in a Vite-bundled way.
+ *
+ * This avoids runtime loading from /node_modules/monaco-editor/... which fails
+ * in packaged desktop builds (e.g. Tauri on macOS).
+ */
+export function initMonaco(): Promise<typeof monaco> {
+  if (!monacoInitPromise) {
+    loader.config({ monaco });
+    monacoInitPromise = loader.init() as Promise<typeof monaco>;
+  }
+  return monacoInitPromise;
+}


### PR DESCRIPTION
## Summary
- fix Monaco initialization to use a Vite-bundled Monaco instance
- avoid runtime loading from `/node_modules/monaco-editor/...` in packaged builds
- centralize Monaco init in `src/lib/services/monaco.ts` and reuse across all editor views

## Root cause
In packaged desktop builds (including macOS DMG), `@monaco-editor/loader` may try to load Monaco assets from runtime paths that do not exist, which causes editor creation to fail silently and leaves the left JSON pane blank or non-editable.

## Fix
- call `loader.config({ monaco })` with imported `monaco-editor` ESM bundle
- expose a shared `initMonaco()` helper
- replace direct `loader.init()` calls in:
  - `MonacoEditor.svelte`
  - `MonacoDiffEditor.svelte`
  - `SchemaView.svelte`
  - `ConvertView.svelte`
  - `CodeGenView.svelte`

## Notes
- This change is low-risk and only affects Monaco bootstrap path.
- Existing theme/language setup remains unchanged.

## Manual verification suggestion
1. Build packaged app on macOS
2. Open app and paste JSON in left editor
3. Verify editor content renders and is editable
