### PR TITLE
fix(editor): update log JSON preview when switching fragments

### DIFF
--- a/src/lib/components/editor/LogJsonFragmentsPanel.svelte
+++ b/src/lib/components/editor/LogJsonFragmentsPanel.svelte
@@ -116,13 +116,22 @@
     };
   }
 
-  $effect(() => {
-    if (!resultEditor || !selectedFragment) return;
-    if (resultEditor.getValue() !== selectedFragment.formatted) {
-      resultEditor.setValue(selectedFragment.formatted);
+  function syncResultEditor(fragment: LogJsonFragment | null) {
+    if (!resultEditor || !fragment) return;
+    if (resultEditor.getValue() !== fragment.formatted) {
+      resultEditor.setValue(fragment.formatted);
       resultEditor.setScrollTop(0);
       resultEditor.setScrollLeft(0);
     }
+  }
+
+  function selectFragment(index: number) {
+    syncResultEditor(fragments[index] || fragments[0] || null);
+    dispatch('select', { index });
+  }
+
+  $effect(() => {
+    syncResultEditor(fragments[selectedIndex] || fragments[0] || null);
   });
 
   $effect(() => {
@@ -246,7 +255,7 @@
             type="button"
             role="tab"
             aria-selected={index === selectedIndex}
-            onclick={() => dispatch('select', { index })}
+            onclick={() => selectFragment(index)}
           >
             <span class="log-json-fragment-row">
               <span class="log-json-fragment-name">{fragment.label}</span>


### PR DESCRIPTION
## Summary

Fix the log JSON fragments panel so selecting a different fragment also updates the read-only Monaco preview editor.

## Root Cause

The fragment list selection state changed on click, but the preview editor was not reliably synchronized with the newly selected fragment. This made the UI look like clicking fragments did not switch the parsed JSON preview.

## Validation

- npm test
- npm run check
- Manual browser verification for object and array log JSON fragments